### PR TITLE
the single quote / apostrophe character has no special meaning - only the double quote does.

### DIFF
--- a/lib/Text/vFile/asData.pm
+++ b/lib/Text/vFile/asData.pm
@@ -75,11 +75,11 @@ sub parse_line {
             # pull the character off to take a looksee
             $text =~ s{(.)}{};
             my $char = $1;
-            if ($char =~ m{['"]} && !$escaped && (!defined($quote) || $char eq $quote)) {
+            if ($char eq '"' && !$escaped) {
                 # either it's defined and matches, in which case we
                 # clear the quote variable, or it's undefined which
                 # makes this quote an opening quote
-                $quote = (defined $quote && $char eq $quote) ? undef : $char;
+                $quote = !$quote;
                 $current .= $char if $keep;
             }
             else {


### PR DESCRIPTION
the single quote / apostrophe character has no special meaning - only the double quote does (i searched RFC 2426 and 2445). the original vCalendar spec also gives no special meaning to the DQUOTE, but i haven't noticed this causing an issue (it's also not an ambiguous character like the single quote / aposthrophe) - i'm converting VERSION:1.0 entries into VERSION:2.0.
