### PR TITLE
Documenting direct access to parse_lines

### DIFF
--- a/lib/Text/vFile/asData.pm
+++ b/lib/Text/vFile/asData.pm
@@ -17,6 +17,9 @@ Text::vFile::asData - parse vFile formatted files into data structures
     or die "couldn't open ics: $!";
   my $data = Text::vFile::asData->new->parse( $fh );
 
+  my $data = Text::vFile::asData->new->parse_lines(
+    @vtext_lines_split_to_array );
+
 =head1 DESCRIPTION
 
 Text::vFile::asData reads vFile format files, such as vCard (RFC 2426) and


### PR DESCRIPTION
Here's two lines of pod to implement your suggestion to document parse_lines instead of creating a  new method. 

Thanks for your quick response.
